### PR TITLE
Use csv.Sniffer and add --encoding and --delimiter arguments

### DIFF
--- a/pretty_csv_diff/__main__.py
+++ b/pretty_csv_diff/__main__.py
@@ -3,9 +3,11 @@ import argparse
 from .pretty_csv_diff import PrettyCsvDiff
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(epilog='https://github.com/telnet23/pretty-csv-diff')
     parser.add_argument('path', nargs=2, help='paths to the two csv files to be compared')
     parser.add_argument('pk', nargs='+', help='name or index of primary key column. multiple columns are allowed')
+    parser.add_argument('--encoding', help='override csv encoding. determined from locale by default')
+    parser.add_argument('--delimiter', help='override csv delimiter. determined heuristically by default')
     args = vars(parser.parse_args())
 
     for formatted_row in PrettyCsvDiff(**args).do():


### PR DESCRIPTION
Now, pretty-csv-diff uses [csv.Sniffer](https://docs.python.org/3/library/csv.html#csv.Sniffer) to heuristically determine the dialect. However, you can override the heuristically determined delimiter with the --delimiter argument. I have also added an --encoding argument.

 Closes #2 